### PR TITLE
Make 'validate' return a message on both failure and success

### DIFF
--- a/library/Refined.hs
+++ b/library/Refined.hs
@@ -32,7 +32,7 @@ import qualified Language.Haskell.TH.Syntax as TH
 
 
 -- |
--- A refinement type, 
+-- A refinement type,
 -- which wraps a value of type @x@,
 -- ensuring that it satisfies a type-level predicate @p@.
 newtype Refined p x =
@@ -65,12 +65,12 @@ refine x =
 -- |
 -- Constructs a 'Refined' value with checking at compile-time using Template Haskell.
 -- E.g.,
--- 
+--
 -- >>> $$(refineTH 23) :: Refined Positive Int
 -- Refined 23
--- 
+--
 -- Here's an example of an invalid value:
--- 
+--
 -- >>> $$(refineTH 0) :: Refined Positive Int
 -- <interactive>:6:4:
 --     Value is not greater than 0
@@ -78,9 +78,9 @@ refine x =
 --     In the expression: $$(refineTH 0) :: Refined Positive Int
 --     In an equation for ‘it’:
 --         it = $$(refineTH 0) :: Refined Positive Int
--- 
--- If it's not evident, the example above indicates a compile-time failure, 
--- which means that the checking was done at compile-time, 
+--
+-- If it's not evident, the example above indicates a compile-time failure,
+-- which means that the checking was done at compile-time,
 -- thus introducing a zero runtime overhead compared to a plain value construction.
 refineTH :: forall p x. (Predicate p x, TH.Lift x) => x -> TH.Q (TH.TExp (Refined p x))
 refineTH =
@@ -92,7 +92,7 @@ refineTH =
 unrefine :: Refined p x -> x
 unrefine =
   unsafeCoerce
-  
+
 
 -- * Predicate
 -------------------------
@@ -233,7 +233,7 @@ type Positive =
 
 -- |
 -- A predicate, which ensures that the value is less than zero.
-type Negative = 
+type Negative =
   LessThan 0
 
 -- |

--- a/library/Refined.hs
+++ b/library/Refined.hs
@@ -15,8 +15,13 @@ module Refined
   LessThan,
   GreaterThan,
   EqualTo,
+  From,
+  To,
+  FromTo,
   Positive,
   Negative,
+  NonPositive,
+  NonNegative,
   ZeroToOne,
 )
 where
@@ -201,10 +206,25 @@ data EqualTo (n :: Nat)
 instance (Ord x, Num x, KnownNat n) => Predicate (EqualTo n) x where
   validate p x =
     if x == fromIntegral x'
-      then (True, "Value is equal to " <> show x')
+      then (True, "Value equals " <> show x')
       else (False, "Value does not equal " <> show x')
     where
       x' = natVal p
+
+-- |
+-- A predicate, which ensures that the value is greater than or equal to the specified type-level number.
+type From n =
+  Not (LessThan n)
+
+-- |
+-- A predicate, which ensures that the value is less than or equal to the specified type-level number.
+type To n =
+  Not (GreaterThan n)
+
+-- |
+-- A predicate, which ensures that the value is inbetween or equal to either of the specified type-level numbers.
+type FromTo mn mx =
+  And (From mn) (To mx)
 
 -- |
 -- A predicate, which ensures that the value is greater than zero.
@@ -217,7 +237,17 @@ type Negative =
   LessThan 0
 
 -- |
+-- A predicate, which ensures that the value is less than or equal to zero.
+type NonPositive =
+  Not Positive
+
+-- |
+-- A predicate, which ensures that the value is greater than or equal to zero.
+type NonNegative =
+  Not Negative
+
+-- |
 -- A range of values from zero to one, including both.
 type ZeroToOne =
-  And (Not (LessThan 0)) (Not (GreaterThan 1))
+  FromTo 0 1
 

--- a/library/Refined.hs
+++ b/library/Refined.hs
@@ -116,12 +116,6 @@ class Predicate p x where
 -- ** Logical
 -------------------------
 
-ensureSentenceEnd :: String -> String
-ensureSentenceEnd str =
-  if not (null str) && not (elem (last str) ['.', '?', '!'])
-    then str ++ "."
-    else str
-
 -- |
 -- A logical negation of a predicate.
 data Not r
@@ -166,10 +160,16 @@ instance (Predicate l x, Predicate r x) => Predicate (Or l r) x where
               "Both subpredicates failed" ++
                 if not (null lMsg && null rMsg)
                   then " (" ++ (intercalate " | " $ filter (not . null) [
-                                if null lMsg then "" else "First with: " ++ lMsg,
-                                if null rMsg then "" else "Second with: " ++ rMsg ]) ++ ")"
+                                  if null lMsg then "" else "First with: " ++ lMsg,
+                                  if null rMsg then "" else "Second with: " ++ rMsg ]) ++ ")"
                   else "."
     in (passed, msg)
+
+ensureSentenceEnd :: String -> String
+ensureSentenceEnd str =
+  if not (null str) && not (elem (last str) ['.', '?', '!'])
+    then str ++ "."
+    else str
 
 
 -- ** Numeric


### PR DESCRIPTION
This makes it possible for 'Not' predicates to return meaningful error messages. This request also adds a few more numeric predicates.

Old behavior:

    >>> refine 2 :: Either String (Refined ZeroToOne Int)
    Left "The right subpredicate failed with: A subpredicate didn't fail"

New behavior:

    >>> refine 2 :: Either String (Refined ZeroToOne Int)
    Left "Value is greater than 1"