### PR TITLE
Control coercions better

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ dist*
 result*
 *.ghc*
 *.project*
+*.hi
+*.o
+.cabal-sandbox
+cabal.sandbox.config
+.stack-work/

--- a/library/Refined/Unsafe.hs
+++ b/library/Refined/Unsafe.hs
@@ -38,23 +38,28 @@
 --   that the refinement predicate holds.
 module Refined.Unsafe
   ( -- * 'Refined'
-    Refined(Refined)
+    Refined
 
     -- ** Creation
   , reallyUnsafeRefine 
   , unsafeRefine
+
+    -- ** Coercion
+  , reallyUnsafeUnderlyingRefined
+  , reallyUnsafeRefinedRefined
   ) where
 
 --------------------------------------------------------------------------------
 
 import           Control.Exception            (Exception(displayException))
-import           Data.Coerce                  (coerce)
+import           Data.Coerce                  (Coercible, coerce)
 import           Data.Either                  (either)
 import           Data.Function                (id)
 
 import           GHC.Err                      (error)
 
 import           Refined.Internal             (Refined(Refined), Predicate, refine, (.>))
+import           Data.Type.Coercion           (Coercion (..))
 
 --------------------------------------------------------------------------------
 
@@ -75,3 +80,12 @@ reallyUnsafeRefine :: x -> Refined p x
 reallyUnsafeRefine = coerce
 {-# INLINE reallyUnsafeRefine #-}
 
+-- | A coercion between a 'Refined' type and a type coercible with
+-- its underlying type.
+reallyUnsafeUnderlyingRefined :: Coercible x y => Coercion x (Refined p y)
+reallyUnsafeUnderlyingRefined = Coercion
+
+-- | A coercion between two 'Refined' types. This may be more convenient
+-- than 'reallyUnsafeUnderlyingRefined' in some cases.
+reallyUnsafeRefinedRefined :: Coercible x y => Coercion (Refined p x) (Refined q y)
+reallyUnsafeRefinedRefined = Coercion

--- a/library/Refined/Unsafe/Type.hs
+++ b/library/Refined/Unsafe/Type.hs
@@ -1,0 +1,10 @@
+-- | This module exports the 'Refined' type with its
+-- constructor. This is very risky! In particular, the 'Coercible'
+-- instances will be visible throughout the importing module.
+-- It is usually better to build the necessary coercions locally
+-- using the utilities in "Refined.Unsafe", but in some cases
+-- it may be more convenient to write a separate module that
+-- imports this one and exports some large coercion.
+module Refined.Unsafe.Type (Refined (..)) where
+
+import Refined.Internal

--- a/refined.cabal
+++ b/refined.cabal
@@ -49,6 +49,7 @@ library
     Refined.Internal 
     Refined.TH
     Refined.Unsafe 
+    Refined.Unsafe.Type
   default-language:
     Haskell2010
   build-depends:


### PR DESCRIPTION
Bringing the `Refined` constructor into scope in a module makes
*all* uses of `coerce` in that module part of the trusted base.
Remove that export from `Refined.Unsafe`, add bindings to bring
the necessary coercions into scope locally, and add a separate
module for the raw type, in case someone really needs it.