### PR TITLE
Bump lower bound on mtl

### DIFF
--- a/refined.cabal
+++ b/refined.cabal
@@ -76,7 +76,7 @@ library
       base             >= 4.9.1 && < 4.14
     , deepseq          >= 1.4 && < 1.5
     , exceptions       >= 0.8 && < 0.11
-    , mtl              >= 2.2.1 && < 2.3
+    , mtl              >= 2.2.2 && < 2.3
     , prettyprinter    >= 1.1.0.1 && < 1.4
     , template-haskell >= 2.9 && < 2.16
     , transformers     >= 0.5 && < 0.6


### PR DESCRIPTION
The use of `liftEither` in `Refined.Internal` requires `mtl >= 2.2.2`:

```
[2 of 8] Compiling Refined.Internal ( src/Refined/Internal.hs, dist/build/Refined/Internal.o )
src/Refined/Internal.hs:1112:16: error:
    Not in scope: ‘MonadError.liftEither’
    Module ‘Control.Monad.Error.Class’ does not export ‘liftEither’.
     |
1112 | exceptRefine = MonadError.liftEither
     |                ^^^^^^^^^^^^^^^^^^^^^
```

You may want to publish new revisions of existing releases as well, on Hackage.