### PR TITLE
Add implementation of shrink for Arbitrary.

### DIFF
--- a/src/Refined.hs
+++ b/src/Refined.hs
@@ -160,7 +160,7 @@ module Refined
 
 import           Control.Exception            (Exception (displayException))
 import           Data.Coerce                  (coerce)
-import           Data.Either                  (isRight)
+import           Data.Either                  (isRight, rights)
 import           Data.Foldable                (foldl')
 import           Data.Proxy                   (Proxy(Proxy))
 import           Data.Text                    (Text)
@@ -301,6 +301,7 @@ instance forall p a. (Arbitrary a, Typeable a, Typeable p, Predicate p a) => Arb
               Nothing -> do
                 loop (runs + 1) gen
         | otherwise = error (refinedGenError (Proxy @p) (Proxy @a))
+  shrink = rights . map refine . QC.shrink . unrefine
 
 refinedGenError :: (Typeable p, Typeable a)
   => Proxy p -> Proxy a -> String

--- a/test/QuickCheck.hs
+++ b/test/QuickCheck.hs
@@ -19,6 +19,8 @@ main = mapM_ quickCheck
   , prop_from
   , prop_to
   , prop_bad
+  , prop_shrink_lt
+  , prop_shrink_gt
   ]
 
 iddy :: (Eq a) => Refined p a -> Bool
@@ -37,10 +39,25 @@ prop_to :: Property
 prop_to = property $ \(r :: Refined (To 9) MyInt) -> iddy r
 
 prop_bad :: Property
-prop_bad = expectFailure $ \(r :: Refined (EqualTo 2 && EqualTo 3) MyInt) -> iddy r
+prop_bad = expectFailure $ ioProperty $ do
+  -- expectFailure expects the error inside the property itself, not while
+  -- generating the argument to the property. So we need to hide generation from
+  -- it.
+  r :: Refined (EqualTo 2 && EqualTo 3) MyInt <- generate arbitrary
+  return $ iddy r
+
+prop_shrink_lt :: Property
+prop_shrink_lt = property $ \(r :: Refined (LessThan 5) MyInt) ->
+  (unrefine <$> shrink r) == shrink (unrefine r)
+
+prop_shrink_gt :: Property
+prop_shrink_gt = property $ \(r :: Refined (GreaterThan 5) MyInt) ->
+  (unrefine <$> shrink r) == (filter (> 5) $ shrink (unrefine r))
 
 newtype MyInt = MyInt Int
   deriving (Eq, Ord, Show, Num)
 
 instance Arbitrary MyInt where
   arbitrary = MyInt <$> choose (0,100)
+  shrink (MyInt 0) = []
+  shrink (MyInt n) = MyInt <$> [0..n-1]


### PR DESCRIPTION
If we can shrink the underlying type, we can shrink the refined types
simply by checking which shrinks still satisfy the predicate.

This made prop_bad fail, I think it moved the (expected) error from a
place where expectFailure could handle it to a place where it couldn't.
So I rearranged that slightly.