### PR TITLE
Add `refineEither` function

### DIFF
--- a/src/Refined.hs
+++ b/src/Refined.hs
@@ -74,6 +74,7 @@ module Refined
   , refineThrow
   , refineFail
   , refineError
+  , refineEither
   , refineTH
   , refineTH_
 
@@ -371,6 +372,23 @@ refineError :: (Predicate p x, MonadError RefineException m)
             => x -> m (Refined p x)
 refineError = refine .> either MonadError.throwError pure
 {-# INLINABLE refineError #-}
+
+-- | Like 'refine', but, when the value doesn't satisfy the predicate, returns
+--   a 'Refined' value with the predicate negated, instead of returning
+--   'RefineException'.
+--
+--   >>> isRight (refineEither @Even @Int 42)
+--   True
+--
+--   >>> isLeft (refineEither @Even @Int 43)
+--   True
+--
+refineEither :: forall p x. (Predicate p x) => x -> Either (Refined (Not p) x) (Refined p x)
+refineEither x =
+  case validate (Proxy @p) x of
+    Nothing -> Right $ Refined x
+    Just _  -> Left  $ Refined x
+{-# INLINABLE refineEither #-}
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
The refineEither function returns an Either containing a value refined
with either the predicate or the negated predicate depending on whether
the value satisfies the predicate.

This closes #76.

I assume the next version will be 0.6.3 but I wasn't sure so haven't included a  `@since` annotation. Happy to add one if that's the right thing to do.