### PR TITLE
Refine new instances

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to the [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## [0.6.3] - Unreleased
+### Added
+- `FromJSONKey` instance for `Refined`
+- `ToJSONKey` instance for `Refined`
+
 ## [0.6.2] - 2021-01-31
 ### Changed
 - `strengthen` no longer returns an `Either`, since the proof
   that it should always succeed is in its constraints.
-- correct `success` documentation 
+- correct `success` documentation
 
 ## [0.6.1] - 2020-08-02
 ### Changed
@@ -36,7 +41,7 @@ and this project adheres to the [Haskell Package Versioning Policy](https://pvp.
 ### Added
 - sized Predicate instances for `Text`
 - sized Predicate instances for strict and lazy `ByteString`
-- INLINABLE pragmas on `refine_` `reifyPredicate` 
+- INLINABLE pragmas on `refine_` `reifyPredicate`
 - `NFData` instance for `Refined`
 - RefineSomeException constructor. Enables recovering
   specific validation exceptions.
@@ -47,7 +52,7 @@ and this project adheres to the [Haskell Package Versioning Policy](https://pvp.
 - @since pragmas to EVERYTHING.
 
 ### Changed
-- lower bound on mtl to 2.2.2 due to use of liftEither. 
+- lower bound on mtl to 2.2.2 due to use of liftEither.
   Thanks to @k0ral for reporting this
 - Generalize sized predicates
 - Allow newer template-haskell (< 0.16 ==> < 0.17)

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ and this project adheres to the [Haskell Package Versioning Policy](https://pvp.
 
 ## [0.6.3] - Unreleased
 ### Added
+- `Hashable` instance for `Refined`
 - `FromJSONKey` instance for `Refined`
 - `ToJSONKey` instance for `Refined`
 

--- a/refined.cabal
+++ b/refined.cabal
@@ -3,7 +3,7 @@ cabal-version:
 name:
   refined
 version:
-  0.6.2
+  0.6.3
 synopsis:
   Refinement types with static and runtime checking
 description:

--- a/refined.cabal
+++ b/refined.cabal
@@ -75,6 +75,7 @@ library
     , bytestring       >= 0.10 && < 0.11
     , deepseq          >= 1.4 && < 1.5
     , exceptions       >= 0.8 && < 0.11
+    , hashable         >= 1.0.0 && < 1.5.0.0
     , mtl              >= 2.2.2 && < 2.3
     , template-haskell >= 2.9 && < 2.18
     , text             >= 1.2 && < 1.3

--- a/src/Refined/Unsafe/Type.hs
+++ b/src/Refined/Unsafe/Type.hs
@@ -48,6 +48,7 @@ module Refined.Unsafe.Type
   ) where
 
 import           Control.DeepSeq              (NFData)
+import           Data.Hashable (Hashable)
 import qualified Language.Haskell.TH.Syntax   as TH
 
 -- | A refinement type, which wraps a value of type @x@.
@@ -58,6 +59,7 @@ newtype Refined p x
   deriving newtype
     ( Eq -- ^ @since 0.1.0.0
     , Ord -- ^ @since 0.1.0.0
+    , Hashable -- ^ @since 0.6.3
     , NFData -- ^ @since 0.5
     )
   deriving stock
@@ -76,4 +78,3 @@ instance (TH.Lift x) => TH.Lift (Refined p x) where
 #if MIN_VERSION_template_haskell(2,16,0)
   liftTyped (Refined a) = [||Refined a||]
 #endif
-


### PR DESCRIPTION
Adds `FromJSONKey`/`ToJSONKey` and `Hashable` instance to `Refined`. Assuming this will trigger an 0.6.3 release, but I'm happy to rework changelog etc if you need.