### PR TITLE
Make predicate type kind polymorphic

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to the [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## Unreleased
+### Changed
+- make `Refined` predicate type `p` kind polymorphic (`p :: Type` -> `p :: k`)
+
 ## [0.6.3] - 2022-01-14
 ### Added
 - `Hashable` instance for `Refined`

--- a/src/Refined.hs
+++ b/src/Refined.hs
@@ -45,6 +45,7 @@
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE PackageImports             #-}
+{-# LANGUAGE PolyKinds                  #-}
 {-# LANGUAGE RoleAnnotations            #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TemplateHaskell            #-}
@@ -567,7 +568,7 @@ data Not p
     )
 
 -- | @since 0.1.0.0
-instance (Predicate p x, Typeable p) => Predicate (Not p) x where
+instance (Predicate (p :: k) x, Typeable p, Typeable k) => Predicate (Not p) x where
   validate p x = do
     maybe (Just (RefineNotException (typeRep p)))
           (const Nothing)
@@ -598,7 +599,7 @@ infixr 3 &&
 type (&&) = And
 
 -- | @since 0.1.0.0
-instance ( Predicate l x, Predicate r x, Typeable l, Typeable r
+instance ( Predicate (l :: k) x, Predicate (r :: k) x, Typeable l, Typeable r, Typeable k
          ) => Predicate (And l r) x where
   validate p x = do
     let a = validate @l undefined x
@@ -638,7 +639,7 @@ infixr 2 ||
 type (||) = Or
 
 -- | @since 0.2.0.0
-instance ( Predicate l x, Predicate r x, Typeable l, Typeable r
+instance ( Predicate (l :: k) x, Predicate (r :: k) x, Typeable l, Typeable r, Typeable k
          ) => Predicate (Or l r) x where
   validate p x = do
     let left  = validate @l undefined x
@@ -675,7 +676,7 @@ data Xor l r
 -- type (^) = Xor
 
 -- | @since 0.5
-instance ( Predicate l x, Predicate r x, Typeable l, Typeable r
+instance ( Predicate (l :: k) x, Predicate (r :: k) x, Typeable l, Typeable r, Typeable k
          ) => Predicate (Xor l r) x where
   validate p x = do
     let left = validate @l undefined x

--- a/src/Refined/Unsafe.hs
+++ b/src/Refined/Unsafe.hs
@@ -29,6 +29,7 @@
 
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE PolyKinds #-}
 #if __GLASGOW_HASKELL__ >= 805
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes #-}

--- a/src/Refined/Unsafe/Type.hs
+++ b/src/Refined/Unsafe/Type.hs
@@ -31,6 +31,7 @@
 {-# LANGUAGE DeriveFoldable             #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PolyKinds                  #-}
 {-# LANGUAGE RoleAnnotations            #-}
 {-# LANGUAGE TemplateHaskell            #-}
 
@@ -54,7 +55,7 @@ import qualified Language.Haskell.TH.Syntax   as TH
 -- | A refinement type, which wraps a value of type @x@.
 --
 --   @since 0.1.0.0
-newtype Refined p x
+newtype Refined (p :: k) x
   = Refined x -- ^ @since 0.1.0.0
   deriving newtype
     ( Eq -- ^ @since 0.1.0.0


### PR DESCRIPTION
I'm not sure if this might have any unintended side-effects, or if there's another solution. But here's my rationale!

I have some data types that I use on both term and type level via DataKinds:

```haskell
data MachineStringRep = C | Pascal Size
data Size = S1 | S2 | S4
data PascalString (size :: Size) = PascalString ByteString
```

A Pascal string is prefixed by its length. I also specify how many bytes that length integer takes up (1 -> Word8 4 -> Word32 etc). Now I need to validate that my Pascal string isn't too long for that length prefix. I could use `refined` like so:

```haskell
data LenPfx (size :: Size)
type PascalString (size :: Size) = Refined (LenPfx size) ByteString
instance Predicate (LenPfx S1) ByteString where -- check BS.length bs < maxBound @Word8
```

But when I look closely, `LenPfx` is just a manually-promoted `Pascal` constructor. I want to do this instead:

```haskell
type PascalString (size :: Size) = Refined ('Pascal size) ByteString
instance Predicate ('Pascal S1) ByteString where -- ...
```

The `Predicate` typeclass is currently `Predicate (p :: Type) a`. Enabling PolyKinds and changing it to `Predicate (p :: k) a` makes the above code work.