### PR TITLE
Generalise type of `refineTH`, `refineTH_`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to the [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
+## Unreleased
+### Changed
+- on GHC >=9, make `refineTH` and `refineTH_` work in any monad
+  `(Quote m, MonadFail m)`.
+
 ## [0.7] - 2022-07-01
 ### Changed
 - make `Refined` predicate type `p` kind polymorphic (`p :: Type` -> `p :: k`)

--- a/src/Refined.hs
+++ b/src/Refined.hs
@@ -439,9 +439,9 @@ refineEither x =
 --
 --   @since 0.1.0.0
 #if MIN_VERSION_template_haskell(2,17,0)
-refineTH :: forall p x. (Predicate p x, TH.Lift x)
+refineTH :: forall p x m. (Predicate p x, TH.Lift x, TH.Quote m, MonadFail m)
   => x
-  -> TH.Code TH.Q (Refined p x)
+  -> TH.Code m (Refined p x)
 refineTH =
   let showException = refineExceptionToTree
         .> showTree True
@@ -468,9 +468,9 @@ refineTH =
 --
 --   @since 0.4.4
 #if MIN_VERSION_template_haskell(2,17,0)
-refineTH_ :: forall p x. (Predicate p x, TH.Lift x)
+refineTH_ :: forall p x m. (Predicate p x, TH.Lift x, TH.Quote m, MonadFail m)
   => x
-  -> TH.Code TH.Q x
+  -> TH.Code m x
 refineTH_ =
   refineTH @p @x
   .> TH.examineCode


### PR DESCRIPTION
As of `template-haskell >= 2.17.0.0`, The `Q` monad was generalised into a [`Quote m`](https://hackage.haskell.org/package/template-haskell-2.18.0.0/docs/Language-Haskell-TH.html#t:Quote) typeclass.

The implementation of `refineTH` already has CPP to deal with the `Code` newtype introduced in `template-haskell-2.17.0.0`, so this is just generalising the types of existing functions.