### PR TITLE
Add more Weaken instances and inference helpers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,9 @@ and this project adheres to the [Haskell Package Versioning Policy](https://pvp.
 
 ## Unreleased
 ### Added
-- `Weaken` instances for `SizeGreaterThan`, `SizeLessThan`, `And`, `Or`
+- `Weaken` instances for `SizeGreaterThan`, `SizeLessThan`.
+- `weakenAndLeft`, `weakenAndRight`, `weakenOrLeft`, `weakenOrRight`
+  type inference helper functions.
 
 ### Changed
 - on GHC >=9, make `refineTH` and `refineTH_` work in any monad

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to the [Haskell Package Versioning Policy](https://pvp.haskell.org/).
 
 ## Unreleased
+### Added
+- `Weaken` instances for `SizeGreaterThan`, `SizeLessThan`, `And`, `Or`
+
 ### Changed
 - on GHC >=9, make `refineTH` and `refineTH_` work in any monad
   `(Quote m, MonadFail m)`.

--- a/src/Refined.hs
+++ b/src/Refined.hs
@@ -136,6 +136,10 @@ module Refined
   , andRight
   , leftOr
   , rightOr
+  , weakenAndLeft
+  , weakenAndRight
+  , weakenOrLeft
+  , weakenOrRight
 
     -- * Strengthening
   , strengthen
@@ -1388,8 +1392,8 @@ rightOr = coerce
 -- @
 --
 --   @since 0.7.1.0
-weakenAndL :: Weaken from to => Refined (And from x) a -> Refined (And to x) a
-weakenAndL = coerce
+weakenAndLeft :: Weaken from to => Refined (And from x) a -> Refined (And to x) a
+weakenAndLeft = coerce
 
 -- | This function helps type inference.
 --   It is equivalent to the following:
@@ -1399,8 +1403,8 @@ weakenAndL = coerce
 -- @
 --
 --   @since 0.7.1.0
-weakenAndR :: Weaken from to => Refined (And x from) a -> Refined (And x to) a
-weakenAndR = coerce
+weakenAndRight :: Weaken from to => Refined (And x from) a -> Refined (And x to) a
+weakenAndRight = coerce
 
 -- | This function helps type inference.
 --   It is equivalent to the following:
@@ -1410,8 +1414,8 @@ weakenAndR = coerce
 -- @
 --
 --   @since 0.7.1.0
-weakenOrL :: Weaken from to => Refined (And from x) a -> Refined (And to x) a
-weakenOrL = coerce
+weakenOrLeft :: Weaken from to => Refined (And from x) a -> Refined (And to x) a
+weakenOrLeft = coerce
 
 -- | This function helps type inference.
 --   It is equivalent to the following:
@@ -1421,8 +1425,8 @@ weakenOrL = coerce
 -- @
 --
 --   @since 0.7.1.0
-weakenOrR :: Weaken from to => Refined (And x from) a -> Refined (And x to) a
-weakenOrR = coerce
+weakenOrRight :: Weaken from to => Refined (And x from) a -> Refined (And x to) a
+weakenOrRight = coerce
 
 -- | Strengthen a refinement by composing it with another.
 --

--- a/src/Refined.hs
+++ b/src/Refined.hs
@@ -1335,14 +1335,6 @@ instance (m <= q)         => Weaken (FromTo n m)        (To q)
 instance (n <= m)         => Weaken (SizeLessThan n)    (SizeLessThan m)
 -- | @since 0.7.1
 instance (m <= n)         => Weaken (SizeGreaterThan n) (SizeGreaterThan m)
--- | @since 0.7.1
-instance Weaken from to   => Weaken (And from x)        (And to x)
--- | @since 0.7.1
-instance Weaken from to   => Weaken (And x from)        (And x to)
--- | @since 0.7.1
-instance Weaken from to   => Weaken (Or from x)         (Or to x)
--- | @since 0.7.1
-instance Weaken from to   => Weaken (Or x from)         (Or x to)
 
 -- | This function helps type inference.
 --   It is equivalent to the following:
@@ -1387,6 +1379,50 @@ leftOr = coerce
 --   @since 0.2.0.0
 rightOr :: Refined r x -> Refined (Or l r) x
 rightOr = coerce
+
+-- | This function helps type inference.
+--   It is equivalent to the following:
+--
+-- @
+-- instance Weaken from to => Weaken (And from x) (And to x)
+-- @
+--
+--   @since 0.7.1.0
+weakenAndL :: Weaken from to => Refined (And from x) a -> Refined (And to x) a
+weakenAndL = coerce
+
+-- | This function helps type inference.
+--   It is equivalent to the following:
+--
+-- @
+-- instance Weaken from to => Weaken (And x from) (And x to)
+-- @
+--
+--   @since 0.7.1.0
+weakenAndR :: Weaken from to => Refined (And x from) a -> Refined (And x to) a
+weakenAndR = coerce
+
+-- | This function helps type inference.
+--   It is equivalent to the following:
+--
+-- @
+-- instance Weaken from to => Weaken (Or from x) (Or to x)
+-- @
+--
+--   @since 0.7.1.0
+weakenOrL :: Weaken from to => Refined (And from x) a -> Refined (And to x) a
+weakenOrL = coerce
+
+-- | This function helps type inference.
+--   It is equivalent to the following:
+--
+-- @
+-- instance Weaken from to => Weaken (Or x from) (Or x to)
+-- @
+--
+--   @since 0.7.1.0
+weakenOrR :: Weaken from to => Refined (And x from) a -> Refined (And x to) a
+weakenOrR = coerce
 
 -- | Strengthen a refinement by composing it with another.
 --

--- a/src/Refined.hs
+++ b/src/Refined.hs
@@ -1314,35 +1314,35 @@ class Weaken from to where
   weaken = coerce
 
 -- | @since 0.2.0.0
-instance (n <= m)         => Weaken (LessThan n)    (LessThan m)
+instance (n <= m)         => Weaken (LessThan n)        (LessThan m)
 -- | @since 0.2.0.0
-instance (n <= m)         => Weaken (LessThan n)    (To m)
+instance (n <= m)         => Weaken (LessThan n)        (To m)
 -- | @since 0.2.0.0
-instance (n <= m)         => Weaken (To n)          (To m)
+instance (n <= m)         => Weaken (To n)              (To m)
 -- | @since 0.2.0.0
-instance (m <= n)         => Weaken (GreaterThan n) (GreaterThan m)
+instance (m <= n)         => Weaken (GreaterThan n)     (GreaterThan m)
 -- | @since 0.2.0.0
-instance (m <= n)         => Weaken (GreaterThan n) (From m)
+instance (m <= n)         => Weaken (GreaterThan n)     (From m)
 -- | @since 0.2.0.0
-instance (m <= n)         => Weaken (From n)        (From m)
+instance (m <= n)         => Weaken (From n)            (From m)
 -- | @since 0.2.0.0
-instance (p <= n, m <= q) => Weaken (FromTo n m)    (FromTo p q)
+instance (p <= n, m <= q) => Weaken (FromTo n m)        (FromTo p q)
 -- | @since 0.2.0.0
-instance (p <= n)         => Weaken (FromTo n m)    (From p)
+instance (p <= n)         => Weaken (FromTo n m)        (From p)
 -- | @since 0.2.0.0
-instance (m <= q)         => Weaken (FromTo n m)    (To q)
+instance (m <= q)         => Weaken (FromTo n m)        (To q)
 -- | @since 0.7.1
-instance (n <= m)         => Weaken (SizeLessThan n) (SizeLessThan m)
+instance (n <= m)         => Weaken (SizeLessThan n)    (SizeLessThan m)
 -- | @since 0.7.1
 instance (m <= n)         => Weaken (SizeGreaterThan n) (SizeGreaterThan m)
 -- | @since 0.7.1
-instance Weaken from to   => Weaken (And from x) (And to x)
+instance Weaken from to   => Weaken (And from x)        (And to x)
 -- | @since 0.7.1
-instance Weaken from to   => Weaken (And x from) (And x to)
+instance Weaken from to   => Weaken (And x from)        (And x to)
 -- | @since 0.7.1
-instance Weaken from to   => Weaken (Or from x) (Or to x)
+instance Weaken from to   => Weaken (Or from x)         (Or to x)
 -- | @since 0.7.1
-instance Weaken from to   => Weaken (Or x from) (Or x to)
+instance Weaken from to   => Weaken (Or x from)         (Or x to)
 
 -- | This function helps type inference.
 --   It is equivalent to the following:

--- a/src/Refined.hs
+++ b/src/Refined.hs
@@ -1331,6 +1331,18 @@ instance (p <= n, m <= q) => Weaken (FromTo n m)    (FromTo p q)
 instance (p <= n)         => Weaken (FromTo n m)    (From p)
 -- | @since 0.2.0.0
 instance (m <= q)         => Weaken (FromTo n m)    (To q)
+-- | @since 0.7.1
+instance (n <= m)         => Weaken (SizeLessThan n) (SizeLessThan m)
+-- | @since 0.7.1
+instance (m <= n)         => Weaken (SizeGreaterThan n) (SizeGreaterThan m)
+-- | @since 0.7.1
+instance Weaken from to   => Weaken (And from x) (And to x)
+-- | @since 0.7.1
+instance Weaken from to   => Weaken (And x from) (And x to)
+-- | @since 0.7.1
+instance Weaken from to   => Weaken (Or from x) (Or to x)
+-- | @since 0.7.1
+instance Weaken from to   => Weaken (Or x from) (Or x to)
 
 -- | This function helps type inference.
 --   It is equivalent to the following:


### PR DESCRIPTION
Adds `instance Weaken` for `SizeLessThan`, `SizeGreaterThan`.
Adds inference helpers `weakenAndLeft`, `weakenAndRight`, `weakenOrLeft`, `weakenOrRight`.

- [ ] The `@since` comments may need to be updated when a new version is released.
