### PR TITLE
add `Predicate1, Refined1` for functor predicates

### DIFF
--- a/src/Refined.hs
+++ b/src/Refined.hs
@@ -97,7 +97,7 @@ module Refined
   , reifyPredicate
 
     -- * 'Predicate1'
-  , Predicate1 (validate1)
+  , Predicate1 (validate1), validate1'
 
     -- * Logical predicates
   , Not(..)
@@ -581,7 +581,33 @@ validate' = validate
 -- constraints to it, you want 'Predicate'.
 class (Typeable p, Typeable k) => Predicate1 (p :: k) f where
   {-# MINIMAL validate1 #-}
+  -- | Check the value @f a@ according to the predicate @p@,
+  --   producing an error 'RefineException' if the value
+  --   does not satisfy.
+  --
+  --   /Note/: 'validate1' is not intended to be used
+  --   directly; instead, it is intended to provide the minimal
+  --   means necessary for other utilities to be derived. As
+  --   such, the 'Maybe' here should be interpreted to mean
+  --   the presence or absence of a 'RefineException', and
+  --   nothing else.
+  --
+  --   Note that due to GHC's type variable order rules, this function has an
+  --   implicit kind in position 1, which makes TypeApplications awkward. Use
+  --   'validate1'' for nicer behaviour.
   validate1 :: Proxy p -> f a -> Maybe RefineException
+
+-- | Check the value @f a@ according to the predicate @p@,
+--   producing an error 'RefineException' if the value
+--   does not satisfy.
+--
+-- Same as 'validate1' but with more convenient type variable order for a better
+-- TypeApplications experience.
+validate1'
+    :: forall {k} p f a
+    .  Predicate1 (p :: k) f => Proxy p -> f a -> Maybe RefineException
+validate1' = validate1
+{-# INLINE validate1' #-}
 
 --------------------------------------------------------------------------------
 

--- a/src/Refined/Unsafe.hs
+++ b/src/Refined/Unsafe.hs
@@ -46,9 +46,11 @@
 module Refined.Unsafe
   ( -- * 'Refined'
     Refined
+  , Refined1
 
     -- ** Creation
   , reallyUnsafeRefine
+  , reallyUnsafeRefine1
   , unsafeRefine
 
     -- ** Coercion
@@ -65,7 +67,7 @@ import           Control.Exception            (displayException)
 import           Data.Coerce                  (coerce)
 
 import           Refined                      (Predicate, refine)
-import           Refined.Unsafe.Type          (Refined(Refined))
+import           Refined.Unsafe.Type          (Refined(Refined), Refined1(Refined1))
 import           Data.Type.Coercion           (Coercion (..))
 #if __GLASGOW_HASKELL__ >= 805
 import           Data.Coerce                  (Coercible)
@@ -93,6 +95,10 @@ unsafeRefine = either (error . displayException) id . refine
 reallyUnsafeRefine :: x -> Refined p x
 reallyUnsafeRefine = coerce
 {-# INLINE reallyUnsafeRefine #-}
+
+reallyUnsafeRefine1 :: f x -> Refined1 p f x
+reallyUnsafeRefine1 = coerce
+{-# INLINE reallyUnsafeRefine1 #-}
 
 -- | A coercion between a type and any refinement of that type.
 --   See "Data.Type.Coercion" for functions manipulating

--- a/src/Refined/Unsafe/Type.hs
+++ b/src/Refined/Unsafe/Type.hs
@@ -29,6 +29,7 @@
 
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveFoldable             #-}
+{-# LANGUAGE DeriveTraversable          #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE PolyKinds                  #-}
@@ -46,6 +47,7 @@
 --   imports this one and exports some large coercion.
 module Refined.Unsafe.Type
   ( Refined(Refined)
+  , Refined1(Refined1)
   ) where
 
 import           Control.DeepSeq              (NFData)
@@ -78,4 +80,32 @@ instance (TH.Lift x) => TH.Lift (Refined p x) where
   lift (Refined a) = [|Refined a|]
 #if MIN_VERSION_template_haskell(2,16,0)
   liftTyped (Refined a) = [||Refined a||]
+#endif
+
+-- | A refinement type, which wraps a value of type @f x@.
+--
+-- The predicate is applied over the functor @f@. Thus, we may safely recover
+-- various 'Functor'y instances, because no matter what you do to the
+-- values inside the functor, the predicate may not be invalidated.
+newtype Refined1 (p :: k) f x
+  = Refined1 (f x)
+  deriving newtype
+    ( Eq
+    , Ord
+    , Hashable
+    , NFData
+    , Functor
+    , Foldable
+    )
+  deriving stock
+    ( Show
+    , Traversable
+    )
+
+type role Refined1 nominal nominal nominal
+
+instance TH.Lift (f a) => TH.Lift (Refined1 p f a) where
+  lift (Refined1 fa) = [|Refined1 fa|]
+#if MIN_VERSION_template_haskell(2,16,0)
+  liftTyped (Refined1 fa) = [||Refined1 fa||]
 #endif


### PR DESCRIPTION
Draft for discussion and visibility. Based off https://github.com/raehik/refined/tree/typeable-constraints-tweak .

This allows us to define refinements over functors, where we are prohibited from accessing the internal type. Importantly, `Refined1 p f a` has safe instances for `Functor` and `Traversable` (given that `f` has the appropriate instance). These can simplify transforming refined types of certain forms.

In other words: usually when you have a `Refined`, you can't change it without re-asserting the predicate. But for a `Refined1`, you're welcome to change the internal elements as you like. You just can't touch the functor itself. So you may have a `Refined1 [] p a`, which is an `[a]` with a functor predicate `p` asserted. You may transform this to a `Refined1 [] p b`. But you may not add or remove elements or change the functor without re-asserting the predicate.

Some predicates were already functor predicates, with instances like `Foldable t => Predicate p (t a)`. These are moved to `Predicate1` e.g. `Foldable t => Predicate1 p t`. Original instances are maintained.

See #94 for earlier discussion.

Non-breaking change.