### PR TITLE
Bump Dependency Bounds

### DIFF
--- a/refined.cabal
+++ b/refined.cabal
@@ -73,14 +73,14 @@ library
   default-language:
     Haskell2010
   build-depends:
-      base             >= 4.11 && < 4.19
-    , bytestring       >= 0.10 && < 0.12
-    , deepseq          >= 1.4 && < 1.5
+      base             >= 4.11 && < 4.20
+    , bytestring       >= 0.10 && < 0.13
+    , deepseq          >= 1.4 && < 1.6
     , exceptions       >= 0.8 && < 0.11
     , hashable         >= 1.0 && < 1.5
     , mtl              >= 2.2.2 && < 2.4
-    , template-haskell >= 2.9 && < 2.21
-    , text             >= 1.2 && < 2.1
+    , template-haskell >= 2.9 && < 2.22
+    , text             >= 1.2 && < 2.2
     , these-skinny     >= 0.7.5 && < 0.8
   if flag(aeson)
     build-depends: aeson >= 0.9 && < 2.3


### PR DESCRIPTION
Bump upper bounds to latest dependency version, adding (eventual) support for GHC 9.8 - currently blocked by `these-skinny`.

Tested with local `these-skinny` via `cabal.project` since it's `master` branch builds on GHC 9.8, with the following command:
```
$ cabal test --test-show-details=direct --enable-tests -w ghc-9.8 --constraint 'aeson==2.2.1.0' --constraint 'bytestring==0.12.1.0' --constraint 'deepseq==1.5.0.0' --constraint 'template-haskell==2.21.0.0' --constraint 'text==2.1.1'

Build profile: -w ghc-9.8.2 -O1
In order, the following will be built (use -v for more details):
 - refined-0.8.1 (test:arbitrary) (first run)
 - refined-0.8.1 (test:compiles) (first run)
Preprocessing test suite 'arbitrary' for refined-0.8.1..
Building test suite 'arbitrary' for refined-0.8.1..
Preprocessing test suite 'compiles' for refined-0.8.1..
Building test suite 'compiles' for refined-0.8.1..
Running 1 test suites...
Test suite arbitrary: RUNNING...
+++ OK, passed 100 tests.
+++ OK, passed 100 tests.
+++ OK, passed 100 tests.
+++ OK, passed 100 tests.
+++ OK, failed as expected. (after 1 test):                            
Exception:
  arbitrary :: Refined (And * * (EqualTo 2) (EqualTo 3)) (MyInt): Failed to generate a value that satisfied the predicate after 100 tries.
  CallStack (from HasCallStack):
    error, called at src/Refined.hs:337:23 in refined-0.8.1-inplace:Refined
+++ OK, passed 100 tests.
+++ OK, passed 100 tests.
Test suite arbitrary: PASS
Test suite logged to:
/home/prikhi/Projects/git/refined/dist-newstyle/build/x86_64-linux/ghc-9.8.2/refined-0.8.1/t/arbitrary/test/refined-0.8.1-arbitrary.log
1 of 1 test suites (1 of 1 test cases) passed.
Running 1 test suites...
Test suite compiles: RUNNING...
refined/test/Compiles.hs: it compiles!
3
3
3
Test suite compiles: PASS
Test suite logged to:
/home/prikhi/Projects/git/refined/dist-newstyle/build/x86_64-linux/ghc-9.8.2/refined-0.8.1/t/compiles/test/refined-0.8.1-compiles.log
1 of 1 test suites (1 of 1 test cases) passed.
```

New release or hackage metadata revision would be :100: 

Asked for the same from `these-skinny` in https://github.com/chessai/these-skinny/issues/6